### PR TITLE
Update .gitattributes to filter unneeded files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Normalize EOL for all files that Git considers text files.
 * text=auto eol=lf
+
+# Only include the addons folder when downloading from the Asset Library.
+/**        export-ignore
+/addons    !export-ignore
+/addons/** !export-ignore


### PR DESCRIPTION
Added recommended filtering (per #4) to git attributes so unneeded files won't be included in the Zip file from the asset library.

While not  entirely necessary this is recommended as best practice by the [Godot documentation](https://docs.godotengine.org/en/stable/community/asset_library/submitting_to_assetlib.html#recommendations).